### PR TITLE
Support equality of ALIAS records

### DIFF
--- a/lib/clouddns/version.rb
+++ b/lib/clouddns/version.rb
@@ -1,3 +1,3 @@
 module Clouddns
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/lib/clouddns/zone_migration.rb
+++ b/lib/clouddns/zone_migration.rb
@@ -70,10 +70,15 @@ module Clouddns
 
     def records_equal? record, fog_record
       # AWS replaces * with \052
-      record.name == fog_record_name(fog_record) &&
+      equal = record.name == fog_record_name(fog_record) &&
         record.type == fog_record.type &&
-          (record.value.respond_to?(:sort) ? record.value.sort : record.value) == (fog_record.value.respond_to?(:sort) ? fog_record.value.sort : fog_record.value) &&
-        record.ttl.to_i == fog_record.ttl.to_i
+          (record.value.respond_to?(:sort) ? record.value.sort : record.value) == (fog_record.value.respond_to?(:sort) ? fog_record.value.sort : fog_record.value)
+      if record.attributes[:alias_target] || fog_record.alias_target
+        equal = equal && record.attributes[:alias_target] == fog_record.alias_target
+      else
+        equal = equal && record.ttl.to_i == fog_record.ttl.to_i
+      end
+      equal
     end
   end
 end


### PR DESCRIPTION
We need to support ALIAS record equality to prevent DNS migrations from removing the ALIAS record.
