### PR TITLE
Support creation of ALIAS records

### DIFF
--- a/lib/clouddns/version.rb
+++ b/lib/clouddns/version.rb
@@ -1,3 +1,3 @@
 module Clouddns
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/lib/clouddns/zone_migration.rb
+++ b/lib/clouddns/zone_migration.rb
@@ -11,7 +11,11 @@ module Clouddns
       end
       class Create < None
         def perform! fog_zone
-          fog_zone.records.create(:type => record.type, :name => record.name, :value => record.value, :ttl => record.ttl)
+          if record.attributes[:alias_target]
+            fog_zone.records.create(:type => record.type, :name => record.name, :value => record.value, :alias_target => record.attributes[:alias_target])
+          else
+            fog_zone.records.create(:type => record.type, :name => record.name, :value => record.value, :ttl => record.ttl)
+          end
         end
         def print_prefix; '+'; end
       end


### PR DESCRIPTION
@denis PTAL

This includes more robust support of ALIAS records, allowing them to be added via the clouddns DSL.
